### PR TITLE
ci: add GitHub Actions matrix (py 3.10-3.13 × pandas 2.x/3.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        pandas-version: ["2.2.*", "3.0.*"]
+        exclude:
+          # pandas 2.2 wheels don't ship for 3.13 yet
+          - python-version: "3.13"
+            pandas-version: "2.2.*"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Create venv & install
+        run: |
+          uv venv --python ${{ matrix.python-version }} .venv
+          uv pip install --python .venv/bin/python -e ".[dev]"
+          uv pip install --python .venv/bin/python "pandas==${{ matrix.pandas-version }}"
+
+      - name: Run tests
+        run: .venv/bin/pytest -v


### PR DESCRIPTION
## Summary

Adds the project's first CI workflow (P7 from the modernization spec).

- `.github/workflows/ci.yml` runs on push to `master` and on PRs targeting `master`.
- Concurrency group cancels in-progress runs of the same ref.
- Matrix: Python 3.10/3.11/3.12/3.13 × pandas 2.2.* / 3.0.* (excludes py3.13 × pandas 2.2.* — no wheels).
- Uses `astral-sh/setup-uv@v6` for fast uv setup with cache.
- Installs the project + `[dev]` extras, then pins matrix pandas version, then runs `pytest -v`.

### Review notes
- codex review APPROVED: "no clear defects in the introduced logic that would break existing code or tests by themselves."

## Test plan
- [x] Local pytest still passes (16 baseline tests unchanged)
- [ ] CI workflow runs successfully on this PR (will gate after this merges since the workflow file lands with it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)