### PR TITLE
feat: add missing_summary and missing_values from feature_describefunctions

### DIFF
--- a/src/lazypandas/__init__.py
+++ b/src/lazypandas/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 from . import io
+from .examine import missing_summary, missing_values
 from .io import Export, Import
 import logging
 
@@ -27,4 +28,4 @@ def export_df(*args, **kwargs):
 
 __version__ = '0.1.0'
 __author__ = 'Vinny Pasceri <vinnypasceri@gmail.com>'
-__all__ = []
+__all__ = ["missing_summary", "missing_values"]

--- a/src/lazypandas/examine.py
+++ b/src/lazypandas/examine.py
@@ -1,0 +1,27 @@
+"""Examine pandas DataFrames for missing values."""
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def missing_summary(df: pd.DataFrame) -> pd.Series:
+    """Per-column count of missing (NaN) values."""
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError(f"Expected DataFrame, got {type(df).__name__}")
+    num_missing = df.isnull().sum()
+    logger.info("Missing-value summary: %s", num_missing.to_dict())
+    return num_missing
+
+
+def missing_values(df: pd.DataFrame, columns: Iterable[str] | None = None) -> int:
+    """Total count of missing values across df, or a column subset."""
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError(f"Expected DataFrame, got {type(df).__name__}")
+    target = df if columns is None else df[list(columns)]
+    return int(np.count_nonzero(target.isnull()))

--- a/tests/test_examine.py
+++ b/tests/test_examine.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import lazypandas as lp
+
+
+@pytest.fixture
+def sample_df():
+    return pd.DataFrame(
+        data={
+            "A": ["Watermelon", "Cherry", "Apple", "Banana", np.nan, np.nan, np.nan,
+                  "Blueberry", "Strawberry", "Grape"],
+            "B": [1, 2, 3, np.nan, 8, 2, 4, 1, 22, 1],
+            "C": ["Blue", "Yellow", "Green", "Red", "Magenta", "Orange", "Pink",
+                  "Purple", np.nan, np.nan],
+        },
+        columns=["A", "B", "C"],
+        index=pd.date_range("1/1/2000", periods=10),
+    )
+
+
+def test_missing_summary_returns_per_column_counts(sample_df):
+    summary = lp.missing_summary(sample_df)
+    assert isinstance(summary, pd.Series)
+    assert summary["A"] == 3
+    assert summary["B"] == 1
+    assert summary["C"] == 2
+
+
+def test_missing_summary_type_error_on_non_dataframe():
+    with pytest.raises(TypeError):
+        lp.missing_summary("not a df")
+
+
+def test_missing_values_total_count(sample_df):
+    assert lp.missing_values(sample_df) == 6
+
+
+def test_missing_values_single_column(sample_df):
+    assert lp.missing_values(sample_df, columns=["A"]) == 3
+
+
+def test_missing_values_multi_column(sample_df):
+    assert lp.missing_values(sample_df, columns=["A", "B"]) == 4
+    assert lp.missing_values(sample_df, columns=["A", "B", "C"]) == 6
+
+
+def test_missing_values_type_error_on_non_dataframe():
+    with pytest.raises(TypeError):
+        lp.missing_values("not a df")
+
+
+def test_missing_values_bad_column(sample_df):
+    with pytest.raises(KeyError):
+        lp.missing_values(sample_df, columns=["nope"])


### PR DESCRIPTION
## Summary

Ports `missing_summary(df) -> Series` and `missing_values(df, columns=None) -> int` from the never-merged 2018 `feature_describefunctions` branch (commit `93faff7`). E1 + E2 from the modernization spec.

- New `src/lazypandas/examine.py` with both functions, modernized: type hints, fixed `logger.exception("msg", e)` signature, dropped the empty `unique()` stub.
- New `tests/test_examine.py` with 7 tests (Series return, per-column counts, scalar count, single/multi-column subset, type errors, bad column raises `KeyError`).
- Exports added to `src/lazypandas/__init__.py`.

### Review notes
- Claude review APPROVED. One minor (`__all__` overwrite dropped wave-1 names) explicitly handled in the chunk-polish PR.

## Test plan
- [x] 7 new examine tests pass
- [x] All wave-1 tests still pass (23 total: 16 wave-1 + 7 examine)
- [x] `lp.missing_summary` and `lp.missing_values` reachable from the public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Codex <noreply@openai.com>