### PR TITLE
feat: add split_and_fill from feature_describefunctions WIP

### DIFF
--- a/src/lazypandas/__init__.py
+++ b/src/lazypandas/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from . import io
 from .examine import missing_summary, missing_values
 from .io import Export, Import
+from .actions import split_and_fill
 import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/lazypandas/actions.py
+++ b/src/lazypandas/actions.py
@@ -28,6 +28,9 @@ def split_and_fill(
     n = int(eligible.sum())
     logger.debug("split_and_fill: backfilling %d rows", n)
 
+    if n and df[target].dtype != object:
+        df[target] = df[target].astype(object)
+
     df.loc[eligible, target] = df.loc[eligible, source].apply(
         lambda x: x.split(separator)[1] if separator in x else None
     )

--- a/src/lazypandas/actions.py
+++ b/src/lazypandas/actions.py
@@ -32,10 +32,10 @@ def split_and_fill(
         df[target] = df[target].astype(object)
 
     df.loc[eligible, target] = df.loc[eligible, source].apply(
-        lambda x: x.split(separator)[1] if separator in x else None
+        lambda x: x.split(separator)[1] if isinstance(x, str) and separator in x else None
     )
     df.loc[eligible, source] = df.loc[eligible, source].apply(
-        lambda x: x.split(separator)[0]
+        lambda x: x.split(separator)[0] if isinstance(x, str) else x
     )
 
     return df

--- a/src/lazypandas/actions.py
+++ b/src/lazypandas/actions.py
@@ -1,0 +1,38 @@
+"""Data-cleaning actions on DataFrames."""
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def split_and_fill(
+    df: pd.DataFrame,
+    source: str,
+    target: str,
+    separator: str,
+) -> pd.DataFrame:
+    """Backfill empty target column by splitting source on separator.
+
+    For rows where ``target`` is NaN and ``source`` is non-null, splits
+    ``source`` on ``separator`` and puts the second part into ``target``
+    while keeping the first part in ``source``. Rows where target is
+    already populated, or source is null, are left untouched.
+    """
+    null_target = df[target].isnull()
+    populated_source = df[source].notnull()
+    eligible = null_target & populated_source
+
+    n = int(eligible.sum())
+    logger.debug("split_and_fill: backfilling %d rows", n)
+
+    df.loc[eligible, target] = df.loc[eligible, source].apply(
+        lambda x: x.split(separator)[1] if separator in x else None
+    )
+    df.loc[eligible, source] = df.loc[eligible, source].apply(
+        lambda x: x.split(separator)[0]
+    )
+
+    return df

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -49,3 +49,20 @@ def test_split_and_fill_returns_dataframe():
     df = pd.DataFrame({"source": ["x:y"], "target": [np.nan]})
     result = lp.split_and_fill(df, source="source", target="target", separator=":")
     assert isinstance(result, pd.DataFrame)
+
+
+def test_split_and_fill_handles_non_string_source_gracefully():
+    """Non-string eligible source values must not crash the call."""
+    df = pd.DataFrame({
+        "source": ["foo:bar", 42, "baz:qux"],
+        "target": [np.nan, np.nan, np.nan],
+    })
+    result = lp.split_and_fill(df.copy(), source="source", target="target", separator=":")
+    # String rows still split.
+    assert result.loc[0, "source"] == "foo"
+    assert result.loc[0, "target"] == "bar"
+    assert result.loc[2, "source"] == "baz"
+    assert result.loc[2, "target"] == "qux"
+    # Non-string source left untouched; target stays NaN.
+    assert result.loc[1, "source"] == 42
+    assert pd.isna(result.loc[1, "target"])

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,51 @@
+# tests/test_actions.py
+import numpy as np
+import pandas as pd
+import pytest
+
+import lazypandas as lp
+
+
+def test_split_and_fill_backfills_target_from_source_split():
+    """When target is NaN and source has 'A:B', split on ':' and put 'B' into target, 'A' back into source."""
+    df = pd.DataFrame({
+        "source": ["foo:bar", "baz:qux", "lone"],
+        "target": [np.nan, np.nan, "preserved"],
+    })
+    result = lp.split_and_fill(df.copy(), source="source", target="target", separator=":")
+
+    # Row 0: target gets "bar", source becomes "foo"
+    assert result.loc[0, "source"] == "foo"
+    assert result.loc[0, "target"] == "bar"
+    # Row 1: target gets "qux", source becomes "baz"
+    assert result.loc[1, "source"] == "baz"
+    assert result.loc[1, "target"] == "qux"
+    # Row 2: target already non-null, source must remain untouched (no separator in it)
+    assert result.loc[2, "source"] == "lone"
+    assert result.loc[2, "target"] == "preserved"
+
+
+def test_split_and_fill_skips_rows_with_filled_target():
+    df = pd.DataFrame({
+        "source": ["foo:bar"],
+        "target": ["already_set"],
+    })
+    result = lp.split_and_fill(df.copy(), source="source", target="target", separator=":")
+    assert result.loc[0, "source"] == "foo:bar"  # unchanged
+    assert result.loc[0, "target"] == "already_set"
+
+
+def test_split_and_fill_skips_rows_with_null_source():
+    df = pd.DataFrame({
+        "source": [np.nan],
+        "target": [np.nan],
+    })
+    result = lp.split_and_fill(df.copy(), source="source", target="target", separator=":")
+    assert pd.isna(result.loc[0, "source"])
+    assert pd.isna(result.loc[0, "target"])
+
+
+def test_split_and_fill_returns_dataframe():
+    df = pd.DataFrame({"source": ["x:y"], "target": [np.nan]})
+    result = lp.split_and_fill(df, source="source", target="target", separator=":")
+    assert isinstance(result, pd.DataFrame)


### PR DESCRIPTION
## Summary

Ports `split_and_fill(df, source, target, separator)` from the 2018 WIP commit `70594ec` on `feature_describefunctions`. A1 from the modernization spec. Original had **no tests** — written here TDD-style.

- New `src/lazypandas/actions.py` with one function: backfills empty target column by splitting source column on a separator (e.g., `"foo:bar"` → source becomes `"foo"`, target gets `"bar"`).
- New `tests/test_actions.py` with 5 tests covering: happy-path backfill, filled-target skip, null-source skip, returns DataFrame, mixed-type source tolerance.
- Exported from `src/lazypandas/__init__.py`.

### Robustness fixes added during review
- **pandas 3.x compatibility**: cast target column to `object` dtype before string assignment (pandas 3.x rejects assigning strings into a float64 column, which is the dtype of an all-NaN column).
- **non-string source**: `isinstance(x, str)` guard inside the apply lambdas — non-string sources (ints, etc.) leave their row untouched instead of crashing the call.

### Review notes
- codex review flagged the non-string source issue as P1; addressed in commit `c77c648` with new regression test.

## Test plan
- [x] 5 actions tests pass
- [x] All wave-1 + wave-2-merged tests still pass (28 total: 16 wave-1 + 7 examine + 5 actions)
- [x] `lp.split_and_fill` reachable from public API
- [x] Verified under pandas 3.0.3 (CI matrix will cover 2.x and 3.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)